### PR TITLE
refactor: modularize EC2 instance and reorganize variables

### DIFF
--- a/instance/main.tf
+++ b/instance/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "test-server" {
+  instance_type          = var.test_server_instance_type
+  tags                   = var.test_server_tags
+  ami                    = var.test_server_ami
+  region                 = var.aws_region
+  key_name               = var.key_pair_name
+  vpc_security_group_ids = [var.security_group_id]
+}

--- a/instance/variables.tf
+++ b/instance/variables.tf
@@ -1,0 +1,31 @@
+variable "test_server_ami" {
+  type    = string
+  default = ""
+}
+
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "test_server_instance_type" {
+  type    = string
+  default = "t2.micro"
+}
+
+variable "test_server_tags" {
+  type = map(string)
+  default = {
+    "test" = "true"
+  }
+}
+
+variable "key_pair_name" {
+  type    = string
+  default = ""
+}
+
+variable "security_group_id" {
+  type    = string
+  default = ""
+}

--- a/main.tf
+++ b/main.tf
@@ -1,22 +1,21 @@
-resource "aws_instance" "test-server" {
-  instance_type = var.test_server_instance_type
-  tags          = var.test_server_tags
-  ami           = var.test_server_ami
-  region        = var.aws_region
-  key_name      = var.key_pair_name
-  vpc_security_group_ids = [module.security_group.security_group_id]
+module "instance" {
+  source                    = "./instance"
+  test_server_ami           = var.test_server_ami
+  test_server_instance_type = var.test_server_instance_type
+  test_server_tags          = var.test_server_tags
+  aws_region                = var.aws_region
+  key_pair_name             = var.key_pair_name
+  security_group_id         = module.security_group.security_group_id
 }
 
 module "vpc" {
   source                               = "./vpc"
   test_server_vpc_cidr_block           = var.test_server_vpc_cidr_block
-  test_server_vpc_enable_dns_hostnames = var.test_server_vpc_enable_dns_hostnames
-  test_server_vpc_enable_dns_support   = var.test_server_vpc_enable_dns_support
   test_server_vpc_tags                 = var.test_server_vpc_tags
 }
 
 module "security_group" {
-  source = "./security-groups"
-  vpc_id = module.vpc.vpc_id
+  source              = "./security-groups"
+  vpc_id              = module.vpc.vpc_id
   security_group_name = var.security_group_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,17 @@
-variable "test_server_ami" {
-  type    = string
-  default = ""
-}
-
+# =======================================================
+# GENERAL CONFIG
+# =======================================================
 variable "aws_region" {
   type    = string
   default = "us-east-1"
+}
+
+# =======================================================
+# EC2 CONFIG
+# =======================================================
+variable "test_server_ami" {
+  type    = string
+  default = ""
 }
 
 variable "test_server_instance_type" {
@@ -13,28 +19,30 @@ variable "test_server_instance_type" {
   default = "t2.micro"
 }
 
-variable "test_server_tags" {
-  type = map(string)
-  default = {
-    "test" = "true"
-  }
+variable "key_pair_name" {
+  type    = string
+  default = ""
 }
 
+# =======================================================
+# SECURITY GROUP CONFIG
+# =======================================================
+variable "security_group_name" {
+  type    = string
+  default = ""
+}
+
+# =======================================================
+# NETWORKING CONFIG
+# =======================================================
 variable "test_server_vpc_cidr_block" {
   type    = string
   default = "10.0.0.0/16"
 }
 
-variable "test_server_vpc_enable_dns_hostnames" {
-  type    = bool
-  default = true
-}
-
-variable "test_server_vpc_enable_dns_support" {
-  type    = bool
-  default = true
-}
-
+# =======================================================
+# RESOURCES TAGGING
+# =======================================================
 variable "test_server_vpc_tags" {
   type    = map(string)
   default = {}
@@ -50,12 +58,10 @@ variable "route_table_tags" {
   default = {}
 }
 
-variable "key_pair_name" {
-  type    = string
-  default = ""
+variable "test_server_tags" {
+  type = map(string)
+  default = {
+    "test" = "true"
+  }
 }
 
-variable "security_group_name" {
-  type = string
-  default = ""
-}


### PR DESCRIPTION
- Convert direct EC2 resource to instance module
- Remove unused VPC DNS variables (enable_dns_hostnames, enable_dns_support)
- Reorganize variables.tf with logical grouping and section headers
- Improve code structure and maintainability